### PR TITLE
feat: migrate comments.js from jquery to vanilla js

### DIFF
--- a/docs/10-other_ways_of_adding_comments_to_a_page.md
+++ b/docs/10-other_ways_of_adding_comments_to_a_page.md
@@ -2,8 +2,7 @@ Step 10: Other ways of including comments in a page
 ===================================================
 
 The default implementation of FOSCommentBundle uses asynchronous javascript
-and jQuery (optionally with easyXDM for cross domain requests) to load a comment
-thread into a page.
+to load a comment thread into a page.
 
 It is possible to include the thread without using javascript to load it, but
 needs additional work inside the controller's action.
@@ -36,7 +35,7 @@ public function somethingAction(Request $request)
 Once you've included this code in your action, some code must be included in your
 template:
 
-``` jinga
+``` jinja
 {% block body %}
 {# ... #}
 <div id="fos_comment_thread" data-thread="{{ thread.id }}">
@@ -51,9 +50,17 @@ template:
 {% endblock body %}
 
 {% block javascript %}
-{# jQuery must be available in the page by this time, and make sure javascript block is after
-  <div id="fos_comment_thread"> in the DOM Tree, for example right before </body> tag
+{# Make sure javascript block is after <div id="fos_comment_thread"> in the DOM Tree,
+   for example right before </body> tag
 #}
+<script>
+    // Configure FOSCommentBundle
+    window.FosComment = window.FosComment || {};
+    window.FosComment.config = {
+        threadId: '{{ thread.id }}',
+        apiBaseUrl: '{{ path('fos_comment_get_threads') }}'
+    };
+</script>
 {% javascripts '@FOSCommentBundle/Resources/public/js/comments.js' %}
 <script src="{{ asset_url }}"></script>
 {% endjavascripts %}

--- a/docs/13-hooking_into_the_js_code.md
+++ b/docs/13-hooking_into_the_js_code.md
@@ -67,7 +67,7 @@ Triggered when the the request about voting a comment succeeds.
 
 Triggered when the comment is inserted into the DOM tree.
 
- - commentHtml: jQuery object to insert into the DOM tree.
+ - commentHtml: HTML element object to insert into the DOM tree.
 
 
 ### fos_comment_removing_comment(  )
@@ -88,10 +88,11 @@ Example:
 =============================
 
 ```js
-$(document)
-    .on('fos_comment_show_form', '.fos_comment_comment_reply_show_form', function (event, data) {
-        // do stuffs
-    });
+FOS_COMMENT.thread_container.addEventListener('fos_comment_show_form', function (event) {
+    // Access event details
+    console.log(event.detail);
+    // do stuffs
+});
 ```
 
 ## That is it!

--- a/docs/4-enable_comments_on_a_page.md
+++ b/docs/4-enable_comments_on_a_page.md
@@ -4,15 +4,7 @@ The recommended way to include comments on a page is using the reference
 javascript provided. The javascript will asynchronously load the comments after
 the page load.
 
-> **Note:**
-> The implementation javascript provided with FOSCommentBundle relies on jQuery 3.x
-> You will need to install this separately and make sure that it is available on the
-> page you want to enable comments on.
->
-> You are welcome to rewrite the reference implementation using another javascript
-> framework.
-
-And the following code at a desired place in the template to load the comments:
+Add the following code at a desired place in the template to load the comments:
 
 ```twig
 {% include '@FOSComment/Thread/async.html.twig' with {'id': 'foo'} %}

--- a/docs/99-faq.md
+++ b/docs/99-faq.md
@@ -8,7 +8,6 @@ No, there is no additional steps required for a basic configuration. Please chec
 * Ensure there are no javascript errors on your page
 * Check the HTTP requests. Should have the following:
  * An initial request to your page
- * A request to the jQuery library
  * A request to a javascript file. Something like /web/js/35a8e64.js
  * A request to the FOSCommentBundle's API. Something like /web/app.php/api/threads/test
 

--- a/src/Resources/public/js/comments.js
+++ b/src/Resources/public/js/comments.js
@@ -8,8 +8,7 @@
  */
 
 /**
- * To use this reference javascript, you must also have jQuery installed. If
- * you want to embed comments cross-domain, then easyXDM CORS is also required.
+ * To use this reference javascript for embedding comments.
  *
  * @todo: expand this explanation (also in the docs)
  *
@@ -17,21 +16,22 @@
  *
  * <div id="fos_comment_thread">#comments</div>
  * <script>
- *     // Set the thread_id if you want comments to be loaded via ajax (url to thread comments api)
- *     var fos_comment_thread_id = 'a_unique_identifier_for_the_thread';
- *     var fos_comment_thread_api_base_url = 'http://example.org/api/threads';
- *
- *     // Optionally set the cors url if you want cross-domain AJAX (also needs easyXDM)
- *     var fos_comment_remote_cors_url = 'http://example.org/cors/index.html';
+ *     // Configure FOSCommentBundle
+ *     window.FosComment = window.FosComment || {};
+ *     window.FosComment.config = {
+ *         threadId: 'a_unique_identifier_for_the_thread',
+ *         view: 'tree',  // optional, defaults to 'tree'
+ *         apiBaseUrl: 'http://example.org/api/threads'
+ *     };
  *
  *     // Optionally set a custom callback function to update the comment count elements
- *     var fos_comment_thread_comment_count_callback = function(elem, threadObject){}
+ *     const fos_comment_thread_comment_count_callback = function(elem, threadObject){}
  *
  *     // Optionally set a different element than div#fos_comment_thread as container
- *     var fos_comment_thread_container = $('#other_element');
+ *     const fos_comment_thread_container = document.querySelector('#other_element');
  *
  * (function() {
- *     var fos_comment_script = document.createElement('script');
+ *     const fos_comment_script = document.createElement('script');
  *     fos_comment_script.async = true;
  *     fos_comment_script.src = 'http://example.org/path/to/this/file.js';
  *
@@ -40,104 +40,238 @@
  * </script>
  */
 
-(function(window, $, easyXDM){
+(function(window){
     "use strict";
-    var FOS_COMMENT = {
+    
+    // Helper function to serialize form data to object
+    function serializeForm(form) {
+        const formData = new FormData(form);
+        const obj = {};
+        for (const pair of formData.entries()) {
+            if (obj[pair[0]] !== undefined) {
+                if (!Array.isArray(obj[pair[0]])) {
+                    obj[pair[0]] = [obj[pair[0]]];
+                }
+                obj[pair[0]].push(pair[1] || '');
+            } else {
+                obj[pair[0]] = pair[1] || '';
+            }
+        }
+        return obj;
+    }
+    
+    // Helper function to convert object to URL parameters
+    function param(obj) {
+        const str = [];
+        for (const p in obj) {
+            if (obj.hasOwnProperty(p)) {
+                if (Array.isArray(obj[p])) {
+                    for (let i = 0; i < obj[p].length; i++) {
+                        str.push(encodeURIComponent(p) + "[]=" + encodeURIComponent(obj[p][i]));
+                    }
+                } else {
+                    str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+                }
+            }
+        }
+        return str.join("&");
+    }
+    
+    // Helper to get dataset value
+    function getData(element, key) {
+        if (key) {
+            return element.dataset[key];
+        }
+        return element.dataset;
+    }
+    
+    // Helper to trigger custom events
+    function trigger(element, eventName, detail) {
+        const event = new CustomEvent(eventName, {
+            detail: detail,
+            bubbles: true,
+            cancelable: true
+        });
+        element.dispatchEvent(event);
+        return event;
+    }
+    
+    // Helper to parse HTML string
+    function parseHTML(html) {
+        const template = document.createElement('template');
+        template.innerHTML = html.trim();
+        return template.content.firstChild;
+    }
+    
+    const FOS_COMMENT = {
         /**
-         * Shorcut post method.
+         * Shortcut post method.
          *
          * @param string url The url of the page to post.
          * @param object data The data to be posted.
-         * @param function success Optional callback function to use in case of succes.
+         * @param function success Optional callback function to use in case of success.
          * @param function error Optional callback function to use in case of error.
+         * @param function complete Optional callback function called on completion.
          */
         post: function(url, data, success, error, complete) {
-            // Wrap the error callback to match return data between jQuery and easyXDM
-            var wrappedErrorCallback = function(response){
-                if('undefined' !== typeof error) {
-                    error(response.responseText, response.status);
+            const formBody = param(data);
+            
+            fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: formBody
+            })
+            .then(function(response) {
+                return response.text().then(function(text) {
+                    return {
+                        text: text,
+                        status: response.status,
+                        ok: response.ok
+                    };
+                });
+            })
+            .then(function(result) {
+                if (result.ok && typeof success !== 'undefined') {
+                    success(result.text, result.status);
+                } else if (!result.ok && typeof error !== 'undefined') {
+                    error(result.text, result.status);
                 }
-            };
-            var wrappedCompleteCallback = function(response){
-                if('undefined' !== typeof complete) {
-                    complete(response.responseText, response.status);
+                if (typeof complete !== 'undefined') {
+                    complete(result.text, result.status);
                 }
-            };
-            $.post(url, data, success).fail(wrappedErrorCallback).always(wrappedCompleteCallback);
+            })
+            .catch(function(err) {
+                if (typeof error !== 'undefined') {
+                    error('', 0);
+                }
+                if (typeof complete !== 'undefined') {
+                    complete('', 0);
+                }
+            });
         },
 
         /**
-         * Shorcut post method.
+         * Shortcut patch method.
          *
-         * @param string url The url of the page to post.
+         * @param string url The url of the page to patch.
          * @param object data The data to be posted.
-         * @param function success Optional callback function to use in case of succes.
+         * @param function success Optional callback function to use in case of success.
          * @param function error Optional callback function to use in case of error.
+         * @param function complete Optional callback function called on completion.
          */
         patch: function(url, data, success, error, complete) {
-            // Wrap the error callback to match return data between jQuery and easyXDM
-            var wrappedErrorCallback = function(response){
-                if('undefined' !== typeof error) {
-                    error(response.responseText, response.status);
+            const formBody = param(data);
+            
+            fetch(url, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: formBody
+            })
+            .then(function(response) {
+                return response.text().then(function(text) {
+                    return {
+                        text: text,
+                        status: response.status,
+                        ok: response.ok
+                    };
+                });
+            })
+            .then(function(result) {
+                if (result.ok && typeof success !== 'undefined') {
+                    success(result.text, result.status);
+                } else if (!result.ok && typeof error !== 'undefined') {
+                    error(result.text, result.status);
                 }
-            };
-            var wrappedCompleteCallback = function(response){
-                if('undefined' !== typeof complete) {
-                    complete(response.responseText, response.status);
+                if (typeof complete !== 'undefined') {
+                    complete(result.text, result.status);
                 }
-            };
-            $.ajax({
-                url: url,
-                type: 'PATCH',
-                data: data,
-            }).done(success).fail(wrappedErrorCallback).always(wrappedCompleteCallback);
+            })
+            .catch(function(err) {
+                if (typeof error !== 'undefined') {
+                    error('', 0);
+                }
+                if (typeof complete !== 'undefined') {
+                    complete('', 0);
+                }
+            });
         },
 
         /**
-         * Shorcut get method.
+         * Shortcut get method.
          *
          * @param string url The url of the page to get.
          * @param object data The query data.
-         * @param function success Optional callback function to use in case of succes.
+         * @param function success Optional callback function to use in case of success.
          * @param function error Optional callback function to use in case of error.
          */
         get: function(url, data, success, error) {
-            // Wrap the error callback to match return data between jQuery and easyXDM
-            var wrappedErrorCallback = function(response){
-                if('undefined' !== typeof error) {
-                    error(response.responseText, response.status);
+            let queryString = param(data);
+            if (queryString) {
+                url += (url.indexOf('?') === -1 ? '?' : '&') + queryString;
+            }
+            
+            fetch(url, {
+                method: 'GET'
+            })
+            .then(function(response) {
+                return response.text().then(function(text) {
+                    return {
+                        text: text,
+                        status: response.status,
+                        ok: response.ok
+                    };
+                });
+            })
+            .then(function(result) {
+                if (result.ok && typeof success !== 'undefined') {
+                    success(result.text, result.status);
+                } else if (!result.ok && typeof error !== 'undefined') {
+                    error(result.text, result.status);
                 }
-            };
-            $.get(url, data, success).fail(wrappedErrorCallback);
+            })
+            .catch(function(err) {
+                if (typeof error !== 'undefined') {
+                    error('', 0);
+                }
+            });
         },
 
         /**
          * Gets the comments of a thread and places them in the thread holder.
          *
          * @param string identifier Unique identifier url for the thread comments.
-         * @param string url Optional url for the thread. Defaults to current location.
+         * @param string permalink Optional url for the thread. Defaults to current location.
          */
         getThreadComments: function(identifier, permalink) {
-            var event = jQuery.Event('fos_comment_before_load_thread');
-
-            event.identifier = identifier;
-            event.params = {
-                permalink: encodeURI(permalink || window.location.href)
-            };
+            const event = trigger(FOS_COMMENT.thread_container, 'fos_comment_before_load_thread', {
+                identifier: identifier,
+                params: {
+                    permalink: encodeURI(permalink || window.location.href)
+                }
+            });
 
             if (typeof window.fos_comment_thread_view !== 'undefined') {
-                event.params.view = window.fos_comment_thread_view;
+                event.detail.params.view = window.fos_comment_thread_view;
             }
 
-            FOS_COMMENT.thread_container.trigger(event);
+            if (event.defaultPrevented) {
+                return;
+            }
+
+            const url = FOS_COMMENT.base_url  + '/' + encodeURIComponent(event.detail.identifier) + '/comments';
+            
             FOS_COMMENT.get(
-                FOS_COMMENT.base_url  + '/' + encodeURIComponent(event.identifier) + '/comments',
-                event.params,
+                url,
+                event.detail.params,
                 // success
                 function(data) {
-                    FOS_COMMENT.thread_container.html(data);
-                    FOS_COMMENT.thread_container.attr('data-thread', event.identifier);
-                    FOS_COMMENT.thread_container.trigger('fos_comment_load_thread', event.identifier);
+                    FOS_COMMENT.thread_container.innerHTML = data;
+                    FOS_COMMENT.thread_container.setAttribute('data-thread', event.detail.identifier);
+                    trigger(FOS_COMMENT.thread_container, 'fos_comment_load_thread', event.detail.identifier);
                 }
             );
         },
@@ -146,302 +280,314 @@
          * Initialize the event listeners.
          */
         initializeListeners: function() {
-            FOS_COMMENT.thread_container.on('submit',
-                'form.fos_comment_comment_new_form',
-                function(e) {
-                    var that = $(this);
-                    var serializedData = FOS_COMMENT.serializeObject(this);
+            // Submit new comment form
+            FOS_COMMENT.thread_container.addEventListener('submit', function(e) {
+                if (!e.target.matches('form.fos_comment_comment_new_form')) {
+                    return;
+                }
+                
+                const form = e.target;
+                const serializedData = serializeForm(form);
 
-                    e.preventDefault();
+                e.preventDefault();
 
-                    var event = $.Event('fos_comment_submitting_form');
-                    that.trigger(event);
+                const event = trigger(form, 'fos_comment_submitting_form');
 
-                    if (event.isDefaultPrevented()) {
-                        return;
+                if (event.defaultPrevented) {
+                    return;
+                }
+
+                FOS_COMMENT.post(
+                    form.action,
+                    serializedData,
+                    // success
+                    function(data, statusCode) {
+                        FOS_COMMENT.appendComment(data, form);
+                        trigger(form, 'fos_comment_new_comment', data);
+                        const formData = getData(form);
+                        if (formData && formData.parent !== '') {
+                            form.closest('.fos_comment_comment_form_holder').remove();
+                        }
+                    },
+                    // error
+                    function(data, statusCode) {
+                        const parent = form.parentElement;
+                        parent.insertAdjacentHTML('afterend', data);
+                        parent.remove();
+                    },
+                    // complete
+                    function(data, statusCode) {
+                        trigger(form, 'fos_comment_submitted_form', statusCode);
                     }
+                );
+            });
 
-                    FOS_COMMENT.post(
-                        this.action,
-                        serializedData,
-                        // success
-                        function(data, statusCode) {
-                            FOS_COMMENT.appendComment(data, that);
-                            that.trigger('fos_comment_new_comment', data);
-                            if (that.data() && that.data().parent !== '') {
-                                that.closest('.fos_comment_comment_form_holder').remove();
+            // Show reply form
+            FOS_COMMENT.thread_container.addEventListener('click', function(e) {
+                if (!e.target.matches('.fos_comment_comment_reply_show_form')) {
+                    return;
+                }
+                
+                const button = e.target;
+                const form_data = getData(button);
+
+                if(button.closest('.fos_comment_comment_reply').classList.contains('fos_comment_replying')) {
+                    return;
+                }
+
+                FOS_COMMENT.get(
+                    form_data.url,
+                    {parentId: form_data.parentId},
+                    function(data) {
+                        button.closest('.fos_comment_comment_reply').classList.add('fos_comment_replying');
+                        button.insertAdjacentHTML('afterend', data);
+                        trigger(button, 'fos_comment_show_form', data);
+                    }
+                );
+            });
+
+            // Cancel reply
+            FOS_COMMENT.thread_container.addEventListener('click', function(e) {
+                if (!e.target.matches('.fos_comment_comment_reply_cancel')) {
+                    return;
+                }
+                
+                const button = e.target;
+                const form_holder = button.closest('.fos_comment_comment_form_holder');
+
+                const event = trigger(form_holder, 'fos_comment_cancel_form');
+
+                if (event.defaultPrevented) {
+                    return;
+                }
+
+                form_holder.closest('.fos_comment_comment_reply').classList.remove('fos_comment_replying');
+                form_holder.remove();
+            });
+
+            // Show edit form
+            FOS_COMMENT.thread_container.addEventListener('click', function(e) {
+                if (!e.target.matches('.fos_comment_comment_edit_show_form')) {
+                    return;
+                }
+                
+                const button = e.target;
+                const form_data = getData(button);
+
+                FOS_COMMENT.get(
+                    form_data.url,
+                    {},
+                    function(data) {
+                        const commentBody = document.querySelector(form_data.container);
+
+                        // save the old comment for the cancel function
+                        commentBody.dataset.original = commentBody.innerHTML;
+
+                        // show the edit form
+                        commentBody.innerHTML = data;
+
+                        trigger(button, 'fos_comment_show_edit_form', data);
+                    }
+                );
+            });
+
+            // Submit edit comment form
+            FOS_COMMENT.thread_container.addEventListener('submit', function(e) {
+                if (!e.target.matches('form.fos_comment_comment_edit_form')) {
+                    return;
+                }
+                
+                const form = e.target;
+
+                FOS_COMMENT.post(
+                    form.action,
+                    serializeForm(form),
+                    // success
+                    function(data) {
+                        FOS_COMMENT.editComment(data);
+                        trigger(form, 'fos_comment_edit_comment', data);
+                    },
+
+                    // error
+                    function(data, statusCode) {
+                        const parent = form.parentElement;
+                        parent.insertAdjacentHTML('afterend', data);
+                        parent.remove();
+                    }
+                );
+
+                e.preventDefault();
+            });
+
+            // Cancel edit
+            FOS_COMMENT.thread_container.addEventListener('click', function(e) {
+                if (!e.target.matches('.fos_comment_comment_edit_cancel')) {
+                    return;
+                }
+                
+                const button = e.target;
+                const commentBody = button.closest('.fos_comment_comment_body');
+                FOS_COMMENT.cancelEditComment(commentBody);
+            });
+
+            // Vote on comment
+            FOS_COMMENT.thread_container.addEventListener('click', function(e) {
+                if (!e.target.matches('.fos_comment_comment_vote')) {
+                    return;
+                }
+                
+                const button = e.target;
+                const form_data = getData(button);
+
+                // Get the form
+                FOS_COMMENT.get(
+                    form_data.url,
+                    {},
+                    function(data) {
+                        // Post it
+                        const parsedHTML = parseHTML(data);
+                        const form = parsedHTML.querySelector('form');
+                        const form_data = getData(form);
+
+                        FOS_COMMENT.post(
+                            form.action,
+                            serializeForm(form),
+                            function(data) {
+                                document.getElementById(form_data.scoreHolder).innerHTML = data;
+                                trigger(button, 'fos_comment_vote_comment', {data: data, form: form});
                             }
-                        },
-                        // error
-                        function(data, statusCode) {
-                            var parent = that.parent();
-                            parent.after(data);
-                            parent.remove();
-                        },
-                        // complete
-                        function(data, statusCode) {
-                            that.trigger('fos_comment_submitted_form', statusCode);
-                        }
-                    );
-                }
-            );
-
-            FOS_COMMENT.thread_container.on('click',
-                '.fos_comment_comment_reply_show_form',
-                function(e) {
-                    var form_data = $(this).data();
-                    var that = $(this);
-
-                    if(that.closest('.fos_comment_comment_reply').hasClass('fos_comment_replying')) {
-                        return that;
+                        );
                     }
+                );
+            });
 
-                    FOS_COMMENT.get(
-                        form_data.url,
-                        {parentId: form_data.parentId},
-                        function(data) {
-                            that.closest('.fos_comment_comment_reply').addClass('fos_comment_replying');
-                            that.after(data);
-                            that.trigger('fos_comment_show_form', data);
-                        }
-                    );
+            // Remove comment
+            FOS_COMMENT.thread_container.addEventListener('click', function(e) {
+                if (!e.target.matches('.fos_comment_comment_remove')) {
+                    return;
                 }
-            );
+                
+                const button = e.target;
+                const form_data = getData(button);
 
-            FOS_COMMENT.thread_container.on('click',
-                '.fos_comment_comment_reply_cancel',
-                function(e) {
-                    var form_holder = $(this).closest('.fos_comment_comment_form_holder');
+                const event = trigger(button, 'fos_comment_removing_comment');
 
-                    var event = $.Event('fos_comment_cancel_form');
-                    form_holder.trigger(event);
+                if (event.defaultPrevented) {
+                    return;
+                }
 
-                    if (event.isDefaultPrevented()) {
-                        return;
+                // Get the form
+                FOS_COMMENT.get(
+                    form_data.url,
+                    {},
+                    function(data) {
+                        // Post it
+                        const parsedHTML = parseHTML(data);
+                        const form = parsedHTML.querySelector('form');
+
+                        FOS_COMMENT.post(
+                            form.action,
+                            serializeForm(form),
+                            function(data) {
+                                const commentHtml = parseHTML(data);
+                                const originalComment = document.getElementById(commentHtml.id);
+                                originalComment.replaceWith(commentHtml);
+                            }
+                        );
                     }
+                );
+            });
 
-                    form_holder.closest('.fos_comment_comment_reply').removeClass('fos_comment_replying');
-                    form_holder.remove();
+            // Toggle commentable
+            FOS_COMMENT.thread_container.addEventListener('click', function(e) {
+                if (!e.target.matches('.fos_comment_thread_commentable_action')) {
+                    return;
                 }
-            );
+                
+                const button = e.target;
+                const form_data = getData(button);
 
-            FOS_COMMENT.thread_container.on('click',
-                '.fos_comment_comment_edit_show_form',
-                function(e) {
-                    var form_data = $(this).data();
-                    var that = $(this);
+                // Get the form
+                FOS_COMMENT.get(
+                    form_data.url,
+                    {},
+                    function(data) {
+                        // Post it
+                        const parsedHTML = parseHTML(data);
+                        const form = parsedHTML.querySelector('form');
 
-                    FOS_COMMENT.get(
-                        form_data.url,
-                        {},
-                        function(data) {
-                            var commentBody = $(form_data.container);
+                        FOS_COMMENT.patch(
+                            form.action,
+                            serializeForm(form),
+                            function(data) {
+                                const parsedHTML = parseHTML(data);
+                                const form = parsedHTML.querySelector('form');
+                                const threadId = getData(form).fosCommentThreadId;
 
-                            // save the old comment for the cancel function
-                            commentBody.data('original', commentBody.html());
-
-                            // show the edit form
-                            commentBody.html(data);
-
-                            that.trigger('fos_comment_show_edit_form', data);
-                        }
-                    );
-                }
-            );
-
-            FOS_COMMENT.thread_container.on('submit',
-                'form.fos_comment_comment_edit_form',
-                function(e) {
-                    var that = $(this);
-
-                    FOS_COMMENT.post(
-                        this.action,
-                        FOS_COMMENT.serializeObject(this),
-                        // success
-                        function(data) {
-                            FOS_COMMENT.editComment(data);
-                            that.trigger('fos_comment_edit_comment', data);
-                        },
-
-                        // error
-                        function(data, statusCode) {
-                            var parent = that.parent();
-                            parent.after(data);
-                            parent.remove();
-                        }
-                    );
-
-                    e.preventDefault();
-                }
-            );
-
-            FOS_COMMENT.thread_container.on('click',
-                '.fos_comment_comment_edit_cancel',
-                function(e) {
-                    FOS_COMMENT.cancelEditComment($(this).parents('.fos_comment_comment_body'));
-                }
-            );
-
-            FOS_COMMENT.thread_container.on('click',
-                '.fos_comment_comment_vote',
-                function(e) {
-                    var that = $(this);
-                    var form_data = that.data();
-
-                    // Get the form
-                    FOS_COMMENT.get(
-                        form_data.url,
-                        {},
-                        function(data) {
-                            // Post it
-                            var form = $($.trim(data)).children('form')[0];
-                            var form_data = $(form).data();
-
-                            FOS_COMMENT.post(
-                                form.action,
-                                FOS_COMMENT.serializeObject(form),
-                                function(data) {
-                                    $('#' + form_data.scoreHolder).html(data);
-                                    that.trigger('fos_comment_vote_comment', data, form);
-                                }
-                            );
-                        }
-                    );
-                }
-            );
-
-            FOS_COMMENT.thread_container.on('click',
-                '.fos_comment_comment_remove',
-                function(e) {
-                    var form_data = $(this).data();
-
-                    var event = $.Event('fos_comment_removing_comment');
-                    $(this).trigger(event);
-
-                    if (event.isDefaultPrevented()) {
-                        return;
+                                // reload the entire thread
+                                FOS_COMMENT.getThreadComments(threadId);
+                            }
+                        );
                     }
-
-                    // Get the form
-                    FOS_COMMENT.get(
-                        form_data.url,
-                        {},
-                        function(data) {
-                            // Post it
-                            var form = $($.trim(data)).children('form')[0];
-
-                            FOS_COMMENT.post(
-                                form.action,
-                                FOS_COMMENT.serializeObject(form),
-                                function(data) {
-                                    var commentHtml = $($.trim(data));
-
-                                    var originalComment = $('#' + commentHtml.attr('id'));
-
-                                    originalComment.replaceWith(commentHtml);
-                                }
-                            );
-                        }
-                    );
-                }
-            );
-
-            FOS_COMMENT.thread_container.on('click',
-                '.fos_comment_thread_commentable_action',
-                function(e) {
-                    var form_data = $(this).data();
-
-                    // Get the form
-                    FOS_COMMENT.get(
-                        form_data.url,
-                        {},
-                        function(data) {
-                            // Post it
-                            var form = $($.trim(data)).children('form')[0];
-
-                            FOS_COMMENT.patch(
-                                form.action,
-                                FOS_COMMENT.serializeObject(form),
-                                function(data) {
-                                    var form = $($.trim(data)).children('form')[0];
-                                    var threadId = $(form).data().fosCommentThreadId;
-
-                                    // reload the intire thread
-                                    FOS_COMMENT.getThreadComments(threadId);
-                                }
-                            );
-                        }
-                    );
-                }
-            );
+                );
+            });
         },
 
         appendComment: function(commentHtml, form) {
-            var form_data = form.data();
+            const form_data = getData(form);
 
             if('' != form_data.parent) {
                 // reply button holder
-                var reply_button_holder = form.closest('.fos_comment_comment_reply');
+                const reply_button_holder = form.closest('.fos_comment_comment_reply');
 
-                var comment_element = form.closest('.fos_comment_comment_show')
-                    .children('.fos_comment_comment_replies');
+                const comment_element = form.closest('.fos_comment_comment_show')
+                    .querySelector('.fos_comment_comment_replies');
 
-                reply_button_holder.removeClass('fos_comment_replying');
+                reply_button_holder.classList.remove('fos_comment_replying');
 
-                comment_element.prepend(commentHtml);
-                comment_element.trigger('fos_comment_add_comment', commentHtml);
+                comment_element.insertAdjacentHTML('afterbegin', commentHtml);
+                trigger(comment_element, 'fos_comment_add_comment', commentHtml);
             } else {
                 // Insert the comment
-                form.after(commentHtml);
-                form.trigger('fos_comment_add_comment', commentHtml);
+                form.insertAdjacentHTML('afterend', commentHtml);
+                trigger(form, 'fos_comment_add_comment', commentHtml);
 
                 // "reset" the form
-                form = $(form[0]);
-                form[0].reset();
-                form.children('.fos_comment_form_errors').remove();
+                form.reset();
+                const errors = form.querySelector('.fos_comment_form_errors');
+                if (errors) {
+                    errors.remove();
+                }
             }
         },
 
         editComment: function(commentHtml) {
-            var commentHtml = $($.trim(commentHtml));
-            var originalCommentBody = $('#' + commentHtml.attr('id')).children('.fos_comment_comment_body');
+            const parsedComment = parseHTML(commentHtml);
+            const originalCommentBody = document.getElementById(parsedComment.id)
+                .querySelector('.fos_comment_comment_body');
 
-            originalCommentBody.html(commentHtml.children('.fos_comment_comment_body').html());
+            originalCommentBody.innerHTML = parsedComment.querySelector('.fos_comment_comment_body').innerHTML;
         },
 
         cancelEditComment: function(commentBody) {
-            commentBody.html(commentBody.data('original'));
+            commentBody.innerHTML = commentBody.dataset.original;
         },
 
         /**
-         * easyXdm doesn't seem to pick up 'normal' serialized forms yet in the
-         * data property, so use this for now.
-         * http://stackoverflow.com/questions/1184624/serialize-form-to-json-with-jquery#1186309
+         * Serialize form to object.
          */
         serializeObject: function(obj)
         {
-            var o = {};
-            var a = $(obj).serializeArray();
-            $.each(a, function() {
-                if (o[this.name] !== undefined) {
-                    if (!o[this.name].push) {
-                        o[this.name] = [o[this.name]];
-                    }
-                    o[this.name].push(this.value || '');
-                } else {
-                    o[this.name] = this.value || '';
-                }
-            });
-            return o;
+            return serializeForm(obj);
         },
 
         loadCommentCounts: function()
         {
-            var threadIds = [];
-            var commentCountElements = $('span.fos-comment-count');
+            const threadIds = [];
+            const commentCountElements = document.querySelectorAll('span.fos-comment-count');
 
-            commentCountElements.each(function(i, elem){
-                var threadId = $(elem).data('fosCommentThreadId');
+            commentCountElements.forEach(function(elem){
+                const threadId = getData(elem, 'fosCommentThreadId');
                 if(threadId) {
                     threadIds.push(threadId);
                 }
@@ -451,21 +597,21 @@
                 FOS_COMMENT.base_url + '.json',
                 {ids: threadIds},
                 function(data) {
-                    // easyXdm doesn't always serialize
-                    if (typeof data != "object") {
-                        data = jQuery.parseJSON(data);
+                    // Parse if string
+                    if (typeof data === "string") {
+                        data = JSON.parse(data);
                     }
 
-                    var threadData = {};
+                    const threadData = {};
 
                     for (var i in data.threads) {
                         threadData[data.threads[i].id] = data.threads[i];
                     }
 
-                    $.each(commentCountElements, function(){
-                        var threadId = $(this).data('fosCommentThreadId');
+                    commentCountElements.forEach(function(elem){
+                        const threadId = getData(elem, 'fosCommentThreadId');
                         if(threadId) {
-                            FOS_COMMENT.setCommentCount(this, threadData[threadId]);
+                            FOS_COMMENT.setCommentCount(elem, threadData[threadId]);
                         }
                     });
                 }
@@ -485,81 +631,40 @@
     };
 
     // Check if a thread container was configured. If not, use default.
-    FOS_COMMENT.thread_container = window.fos_comment_thread_container || $('#fos_comment_thread');
+    FOS_COMMENT.thread_container = window.fos_comment_thread_container || document.getElementById('fos_comment_thread');
 
-    // AJAX via easyXDM if this is configured
-    if(typeof window.fos_comment_remote_cors_url != "undefined") {
-        /**
-         * easyXDM instance to use
-         */
-        FOS_COMMENT.easyXDM = easyXDM.noConflict('FOS_COMMENT');
-
-        /**
-         * Shorcut request method.
-         *
-         * @param string method The request method to use.
-         * @param string url The url of the page to request.
-         * @param object data The data parameters.
-         * @param function success Optional callback function to use in case of succes.
-         * @param function error Optional callback function to use in case of error.
-         */
-        FOS_COMMENT.request = function(method, url, data, success, error) {
-            // wrap the callbacks to match the callback parameters of jQuery
-            var wrappedSuccessCallback = function(response){
-                if('undefined' !== typeof success) {
-                    success(response.data, response.status);
-                }
-            };
-            var wrappedErrorCallback = function(response){
-                if('undefined' !== typeof error) {
-                    error(response.data.data, response.data.status);
-                }
-            };
-
-            // todo: is there a better way to do this?
-            FOS_COMMENT.xhr.request({
-                    url: url,
-                    method: method,
-                    data: data
-            }, wrappedSuccessCallback, wrappedErrorCallback);
-        };
-
-        FOS_COMMENT.post = function(url, data, success, error) {
-            this.request('POST', url, data, success, error);
-        };
-
-        FOS_COMMENT.get= function(url, data, success, error) {
-            // make data serialization equals to that of jquery
-            var params = jQuery.param(data);
-            url += '' != params ? '?' + params : '';
-
-            this.request('GET', url, undefined, success, error);
-        };
-
-        /* Initialize xhr object to do cross-domain requests. */
-        FOS_COMMENT.xhr = new FOS_COMMENT.easyXDM.Rpc({
-                remote: window.fos_comment_remote_cors_url
-        }, {
-            remote: {
-                request: {} // request is exposed by /cors/
-            }
-        });
+    // Get configuration from FosComment namespace
+    const config = window.FosComment && window.FosComment.config;
+    
+    if (!config) {
+        console.error('[FOSComment] Configuration not found. Make sure window.FosComment.config is set before loading comments.js');
+        return;
     }
-
-    // set the appropriate base url
-    FOS_COMMENT.base_url = window.fos_comment_thread_api_base_url;
+    
+    // Set the base URL from config
+    FOS_COMMENT.base_url = config.apiBaseUrl;
+    
+    // Get thread id and view from config
+    const threadId = config.threadId;
+    const threadView = config.view;
 
     // Load the comment if there is a thread id defined.
-    if(typeof window.fos_comment_thread_id != "undefined") {
+    if (threadId) {
+        // Store view in global for compatibility with getThreadComments
+        if (threadView) {
+            window.fos_comment_thread_view = threadView;
+        }
+        
         // get the thread comments and init listeners
-        FOS_COMMENT.getThreadComments(window.fos_comment_thread_id);
+        FOS_COMMENT.getThreadComments(threadId);
     }
 
     if(typeof window.fos_comment_thread_comment_count_callback != "undefined") {
         FOS_COMMENT.setCommentCount = window.fos_comment_thread_comment_count_callback;
     }
 
-    if($('span.fos-comment-count').length > 0) {
+    const commentCountElements = document.querySelectorAll('span.fos-comment-count');
+    if(commentCountElements.length > 0) {
         FOS_COMMENT.loadCommentCounts();
     }
 
@@ -567,4 +672,4 @@
 
     window.fos = window.fos || {};
     window.fos.Comment = FOS_COMMENT;
-})(window, window.jQuery, window.easyXDM);
+})(window);

--- a/src/Resources/views/Thread/async.html.twig
+++ b/src/Resources/views/Thread/async.html.twig
@@ -12,16 +12,17 @@
 <div id="fos_comment_thread"></div>
 
 <script>
-    // thread id
-    var fos_comment_thread_id = '{{ id }}';
-    var fos_comment_thread_view = '{{ view|default('tree') }}';
-
-    // api base url to use for initial requests
-    var fos_comment_thread_api_base_url = '{{ path('fos_comment_get_threads') }}';
+    // Configure FOSCommentBundle
+    window.FosComment = window.FosComment || {};
+    window.FosComment.config = {
+        threadId: '{{ id }}',
+        view: '{{ view|default('tree') }}',
+        apiBaseUrl: '{{ path('fos_comment_get_threads') }}'
+    };
 
     // Snippet for asynchronously loading the comments
     (function() {
-        var fos_comment_script = document.createElement('script');
+        const fos_comment_script = document.createElement('script');
         fos_comment_script.async = true;
         fos_comment_script.src = '{{ asset('bundles/foscomment/js/comments.js') }}';
 

--- a/tests/Functional/Bundle/CommentBundle/Resources/views/Comment/async.html.twig
+++ b/tests/Functional/Bundle/CommentBundle/Resources/views/Comment/async.html.twig
@@ -1,6 +1,5 @@
 {% extends '::base.html.twig' %}
 
 {% block body %}
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 {% include '@FOSComment/Thread/async.html.twig' with { 'id': id } %}
 {% endblock body %}

--- a/tests/Functional/Bundle/CommentBundle/Resources/views/Comment/inline.html.twig
+++ b/tests/Functional/Bundle/CommentBundle/Resources/views/Comment/inline.html.twig
@@ -11,7 +11,6 @@
 
 {% block javascript %}
 {% javascripts '@FOSCommentBundle/Resources/assets/js/comments.js' %}
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="{{ asset_url }}">
 // URI identifier for the thread comments
 var fos_comment_thread_id = '{{ path('fos_comment_get_thread_comments', {'id': thread.id}) }}';


### PR DESCRIPTION
# Migrate from jQuery to Vanilla JavaScript and update configuration API

## Description
Complete migration of FOSCommentBundle JavaScript code from jQuery to vanilla JavaScript (ES6+). This includes removing jQuery and easyXDM dependencies, implementing modern JavaScript features (Fetch API, const/let, arrow functions, CustomEvents), and introducing a new object-based configuration format for better API design.

## Breaking Changes
**Configuration API:**
- Old global variables (`fos_comment_thread_id`, `fos_comment_thread_api_base_url`, `fos_comment_thread_view`) replaced with `window.FosComment.config` object
- easyXDM cross-domain support removed
- jQuery dependency removed

## Scope
- Update async.html.twig template to use new configuration syntax (`window.FosComment.config`)
- Replace `var` with `const` in JavaScript code for modern practices
- Update documentation comments in comments.js with new configuration examples and modern JavaScript syntax
- Update all documentation files to reflect new API usage
- Remove jQuery dependency from test templates

## Files Changed
**Template files:**
- `src/Resources/views/Thread/async.html.twig` - Updated to use new configuration object

**JavaScript:**
- `src/Resources/public/js/comments.js` - Updated JSDoc comments, replaced var with const/let, modernized code

**Documentation:**
- `docs/4-enable_comments_on_a_page.md` - Updated basic usage examples
- `docs/10-other_ways_of_adding_comments_to_a_page.md` - Added configuration example for manual loading
- `docs/13-hooking_into_the_js_code.md` - Updated event listener examples
- `docs/99-faq.md` - Minor documentation update

**Test files:**
- `tests/Functional/Bundle/CommentBundle/Resources/views/Comment/async.html.twig` - Removed jQuery dependency
- `tests/Functional/Bundle/CommentBundle/Resources/views/Comment/inline.html.twig` - Removed jQuery script tag

## Technical Changes
**Old syntax (removed):**
```javascript
var fos_comment_thread_id = '{{ id }}';
var fos_comment_thread_view = '{{ view|default('tree') }}';
var fos_comment_thread_api_base_url = '{{ path('fos_comment_get_threads') }}';
```
**New syntax:**
```javascript
window.FosComment = window.FosComment || {};
window.FosComment.config = {
    threadId: '{{ id }}',
    view: '{{ view|default('tree') }}',
    apiBaseUrl: '{{ path('fos_comment_get_threads') }}'
};
```